### PR TITLE
Directory Separator Fix for Unit Tests

### DIFF
--- a/tests/Aura/Autoload/LoaderTest.php
+++ b/tests/Aura/Autoload/LoaderTest.php
@@ -279,10 +279,12 @@ class LoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($class1, $actual);
         
         $expect = [
-            $class1 => dirname( dirname( __DIR__ ) ) . DIRECTORY_SEPARATOR . 'Aura' . DIRECTORY_SEPARATOR . 'Autoload' . DIRECTORY_SEPARATOR . 'Foo' . DIRECTORY_SEPARATOR . 'MockAutoloadCliClass.php',
-            $class2 => dirname( dirname( __DIR__ ) ) . DIRECTORY_SEPARATOR . 'Aura' . DIRECTORY_SEPARATOR . 'Autoload' . DIRECTORY_SEPARATOR . 'Bar' . DIRECTORY_SEPARATOR . 'MockAutoloadRouterClass.php',
+            $class1 => dirname( dirname( __DIR__ ) ) . DIRECTORY_SEPARATOR . 'Aura/Autoload/Foo/MockAutoloadCliClass.php',
+            $class2 => dirname( dirname( __DIR__ ) ) . DIRECTORY_SEPARATOR . 'Aura/Autoload/Bar/MockAutoloadRouterClass.php',
         ];
-        
+
+        $expect = str_replace('/', DIRECTORY_SEPARATOR, $expect);
+
         $actual = $autoloader->getLoaded();
         $this->assertSame($expect, $actual);
     }

--- a/tests/Aura/Autoload/LoaderTest.php
+++ b/tests/Aura/Autoload/LoaderTest.php
@@ -279,8 +279,8 @@ class LoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($class1, $actual);
         
         $expect = [
-            $class1 => dirname( dirname( __DIR__ ) ) . DIRECTORY_SEPARATOR . 'Aura/Autoload/Foo/MockAutoloadCliClass.php',
-            $class2 => dirname( dirname( __DIR__ ) ) . DIRECTORY_SEPARATOR . 'Aura/Autoload/Bar/MockAutoloadRouterClass.php',
+            $class1 => dirname( dirname( __DIR__ ) ) . DIRECTORY_SEPARATOR . 'Aura' . DIRECTORY_SEPARATOR . 'Autoload' . DIRECTORY_SEPARATOR . 'Foo' . DIRECTORY_SEPARATOR . 'MockAutoloadCliClass.php',
+            $class2 => dirname( dirname( __DIR__ ) ) . DIRECTORY_SEPARATOR . 'Aura' . DIRECTORY_SEPARATOR . 'Autoload' . DIRECTORY_SEPARATOR . 'Bar' . DIRECTORY_SEPARATOR . 'MockAutoloadRouterClass.php',
         ];
         
         $actual = $autoloader->getLoaded();


### PR DESCRIPTION
Replaced static Unix-Style Directory Seperators with dynamic ones from PHPs DIRECTORY_SEPARATOR Constant
Previously all phpunit tests would fail on Windows Machines
